### PR TITLE
Add behavioral quickcheck test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ readme = "README.md"
 repository = "https://github.com/gifnksm/topological-sort-rs"
 description = "Performs topological sorting."
 documentation = "https://docs.rs/topological-sort/~0.0"
+
+[dev-dependencies]
+quickcheck_macros = "0.9"
+quickcheck = "0.9"
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,7 @@ mod test {
     fn topo_test_quickcheck(n: usize, edges: Vec<(usize,usize)>) {
         use std::collections::{HashMap,HashSet};
 
-        let n = if n == 0 { 1 } else { n };
+        let n = n.max(1);
         let mut marked = vec![false;n];
         let edges = edges.into_iter().map(|(x,y)| (x%n,y%n)).collect::<Vec<_>>();
         let mut deps = HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,11 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::hash::Hash;
 use std::iter::FromIterator;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+#[cfg(test)]
+extern crate quickcheck;
 
 #[derive(Clone)]
 struct Dependency<T> {
@@ -376,5 +381,66 @@ mod test {
         assert_eq!(ts.pop(), Some("stone"));
         assert!(ts.pop().is_none());
         println!("{:?}", ts);
+    }
+
+    #[quickcheck]
+    fn topo_test_quickcheck(n: usize, edges: Vec<(usize,usize)>) {
+        use std::collections::{HashMap,HashSet};
+
+        let n = if n == 0 { 1 } else { n };
+        let mut marked = vec![false;n];
+        let edges = edges.into_iter().map(|(x,y)| (x%n,y%n)).collect::<Vec<_>>();
+        let mut deps = HashMap::new();
+        let mut toposort = TopologicalSort::<usize>::new();
+
+        for i in 0..n {
+            let _ = deps.insert(i,HashSet::new());
+            assert!(toposort.insert(i));
+        }
+
+        for (op,inp) in edges.iter().map(|(x,y)| (y,x)) {
+            let inps = deps.get_mut(op).unwrap();
+            let _ = inps.insert(*inp);
+        }
+
+        let deps = deps;
+        for (inp,op) in edges {
+            toposort.add_dependency(inp,op);
+        }
+        while let Some(x) = toposort.pop() {
+            for dep in deps.get(&x).unwrap().iter() {
+                assert!(marked[*dep]);
+            }
+            marked[x] = true;
+        }
+
+        if toposort.len() != 0 {
+            let dep_fixed = {
+                let mut ret = (0..n).map(|i| (i,HashSet::new())).collect::<HashMap<_,_>>();
+                let mut new_to_add = deps.clone();
+
+                while !new_to_add.is_empty() {
+                    for (k,v) in new_to_add.drain() {
+                        let inps = ret.get_mut(&k).unwrap();
+                        inps.extend(v.into_iter());
+                    }
+                    for (k,vs) in ret.iter() {
+                        for k2 in vs.iter() {
+                            for v2 in ret.get(k2).unwrap().iter() {
+                                if !vs.contains(v2) {
+                                    let _ = new_to_add.entry(*k).or_insert_with(HashSet::new).insert(*v2);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                ret
+            };
+
+            assert!(dep_fixed.into_iter().any(|(op,deps)| deps.contains(&op)));
+        } else {
+            assert!(marked.into_iter().all(|x| x));
+        }
     }
 }


### PR DESCRIPTION
This adds a behavioral test that uses `quickcheck` to generate random directed graphs, then checks that:
 - If `.pop()` produces a value, it has already produced all that value's `pred`s
 - If `.pop()` runs out with nonzero `.len()`, we can find a cycle
 - If `.pop()` runs out with zero `.len()`, we have visited all nodes.