### PR TITLE
Add changelog and align tooling config

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,11 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD060": {
+    "style": "aligned"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,172 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+* Added `CHANGELOG.md`.
+
+### Changed
+
+* **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new edge and `false` when the edge already existed.
+* Raised the minimum supported Rust version to Rust 1.85.0 and updated CI to test against it, in line with the project's 0.x MSRV policy.
+* Updated project maintenance and tooling.
+  * Added regression tests covering self-dependencies and cycles created with `DependencyLink`.
+  * Added Markdown lint configuration.
+  * Moved `cargo-release` configuration into `release.toml`.
+  * Moved Rust and Clippy lint configuration from crate attributes into `Cargo.toml`.
+  * Started tracking `Cargo.lock` in the repository.
+  * Updated CI actions and development dependencies.
+
+### Fixed
+
+* Updated copyright and license statements.
+
+## [0.2.2] - 2022-07-18
+
+### Changed
+
+* Marked the crate as passively maintained.
+* Updated release automation.
+  * Moved release-time configuration into Cargo metadata.
+  * Removed the tag-triggered GitHub Actions publish workflow.
+
+## [0.2.1] - 2022-07-17
+
+### Fixed
+
+* Fixed the manifest to use the supported `rust-version` key for declaring the MSRV.
+
+## [0.2.0] - 2022-07-17
+
+### Added
+
+* Implemented `Default` for `TopologicalSort<T>`, allowing construction with `TopologicalSort::default()`.
+
+### Changed
+
+* Migrated the crate to Rust 2018 and declared Rust 1.43.1 as the minimum supported Rust version.
+* Expanded project automation and test coverage.
+  * Added property-based tests covering ordering and cycle detection behavior.
+  * Added GitHub Actions CI, release automation, and Dependabot configuration.
+  * Removed the Travis CI configuration.
+
+## [0.1.0] - 2018-01-03
+
+### Changed
+
+* Updated CI configuration and made ignored return values explicit to satisfy newer Rust warnings.
+
+## [0.0.10] - 2017-09-10
+
+### Changed
+
+* Changed `TopologicalSort::insert()` and `TopologicalSort::add_dependency()` to accept arguments implementing `Into<T>`.
+
+## [0.0.9] - 2017-05-30
+
+### Added
+
+* Added the `DependencyLink<T>` type and `TopologicalSort::add_link()` for registering dependency edges as values.
+* Implemented `From<(T, T)>` for `DependencyLink<T>`, allowing dependency links to be created from tuples.
+* Implemented `FromIterator<DependencyLink<T>>` for `TopologicalSort<T>`, allowing a sorter to be built from an iterator of dependency links.
+* Implemented `Clone` for `TopologicalSort<T>` and `Copy`, `Clone`, and `Debug` for `DependencyLink<T>`.
+
+### Changed
+
+* Documentation moved to docs.rs.
+* Updated project tooling.
+  * Switched CI from `travis-cargo` helpers to direct Cargo commands.
+
+### Removed
+
+* Removed Travis-based GitHub Pages documentation publishing.
+
+## [0.0.8] - 2017-05-01
+
+### Added
+
+* Implemented `fmt::Debug` for `TopologicalSort<T>`.
+* Added `TopologicalSort::peek()` and `TopologicalSort::peek_all()` to inspect items that are ready to pop without removing them.
+
+## [0.0.7] - 2016-08-08
+
+### Added
+
+* Added `TopologicalSort::insert()` to register elements that have no dependencies.
+* Implemented `FromIterator<T>` for partially ordered element types, deriving dependency edges from `partial_cmp()`.
+
+## [0.0.6] - 2016-01-11
+
+### Added
+
+* Added Apache-2.0 as an alternative license alongside MIT.
+
+### Changed
+
+* Renamed the crate for use as `topological_sort` in code and documentation.
+* Updated project tooling for newer Rust versions.
+  * Migrated CI to `travis-cargo`, expanded testing to nightly, beta, and stable Rust, and enabled documentation and coverage reporting.
+
+### Fixed
+
+* Updated documentation examples to use the correct `topological_sort` crate name.
+
+## [0.0.5] - 2015-03-29
+
+### Changed
+
+* Updated the crate for `rustc 1.0.0-nightly (199bdcfef 2015-03-26)`.
+  * Removed the now-unneeded `std_misc` feature gate.
+* This removed the last nightly-only feature gate, so this release became buildable on stable Rust once Rust 1.0 shipped on 2015-05-15.
+
+## [0.0.4] - 2015-02-21
+
+### Changed
+
+* Updated the crate for `rustc 1.0.0-nightly (522d09dfe 2015-02-19)`.
+  * Switched generic bounds back to plain `Hash`.
+  * Added the `std_misc` feature gate.
+
+## [0.0.3] - 2015-01-09
+
+### Changed
+
+* Updated the crate for `rustc 1.0.0-dev (20bce4481 2015-01-09 04:14:53 +0000)`.
+  * **(Breaking Change)** Changed `TopologicalSort::len()` to return `usize` instead of `uint`.
+  * **(Breaking Change)** Changed the public trait bounds on `TopologicalSort<T>` and its `Iterator` implementation from `Hash` to `Hash<Hasher>`.
+
+## [0.0.2] - 2015-01-07
+
+### Changed
+
+* Updated the crate for `rustc 1.0.0-dev (9e4e524e0 2015-01-07 05:31:23 +0000)`.
+  * Removed the crate-level `associated_types` feature gate after associated types no longer required opting in.
+
+## [0.0.1] - 2015-01-06
+
+* First release
+
+<!-- next-url -->
+[Unreleased]: https://github.com/gifnksm/topological-sort-rs/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/gifnksm/topological-sort-rs/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/gifnksm/topological-sort-rs/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/gifnksm/topological-sort-rs/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.10...v0.1.0
+[0.0.10]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.9...v0.0.10
+[0.0.9]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.8...v0.0.9
+[0.0.8]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/gifnksm/topological-sort-rs/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/gifnksm/topological-sort-rs/releases/tag/v0.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,21 +3,36 @@ name = "topological-sort"
 version = "0.2.2"
 edition = "2018"
 rust-version = "1.85.0"
-authors = ["gifnksm <makoto.nksm+github@gmail.com>"]
-license = "MIT OR Apache-2.0"
-readme = "README.md"
-repository = "https://github.com/gifnksm/topological-sort-rs"
 description = "Performs topological sorting."
 documentation = "https://docs.rs/topological-sort"
+readme = "README.md"
+repository = "https://github.com/gifnksm/topological-sort-rs"
+license = "MIT OR Apache-2.0"
+
+[dev-dependencies]
+quickcheck = "1.0.3"
+quickcheck_macros = "1.2.0"
 
 [badges]
 maintenance = { status = "passively-maintained" }
 
-[dev-dependencies]
-quickcheck_macros = "1.2.0"
-quickcheck = "1.0.3"
+[lints.clippy]
+if_not_else = "warn"
+invalid_upcast_comparisons = "warn"
+items_after_statements = "warn"
+mut_mut = "warn"
+never_loop = "warn"
+nonminimal_bool = "warn"
+used_underscore_binding = "warn"
 
-[package.metadata.release]
-pre-release-replacements = [
-    { file = "README.md", search = "topological-sort = \"[0-9\\.]+\"", replace = "{{crate_name}} = \"{{version}}\"" }
-]
+[lints.rust]
+missing_copy_implementations = "warn"
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+nonstandard_style = "warn"
+trivial_casts = "warn"
+trivial_numeric_casts = "warn"
+unused = "warn"
+unused_extern_crates = "warn"
+unused_import_braces = "warn"
+unused_qualifications = "warn"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![license](https://img.shields.io/crates/l/topological-sort.svg)](#license)
 [![crates.io](https://img.shields.io/crates/v/topological-sort.svg)](https://crates.io/crates/topological-sort)
 [![docs.rs](https://img.shields.io/docsrs/topological-sort/latest)](https://docs.rs/topological-sort/latest/)
-[![rust 1.61.0+ badge](https://img.shields.io/badge/rust-1.61.0+-93450a.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![rust 1.85.0+ badge](https://img.shields.io/badge/rust-1.85.0+-93450a.svg)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![Rust CI](https://github.com/gifnksm/topological-sort-rs/actions/workflows/rust-ci.yml/badge.svg)](https://github.com/gifnksm/topological-sort-rs/actions/workflows/rust-ci.yml)
 [![Codecov](https://codecov.io/gh/gifnksm/topological-sort-rs/branch/master/graph/badge.svg?token=VreVOoM3Yb)](https://codecov.io/gh/gifnksm/topological-sort-rs)
 
@@ -23,8 +23,7 @@ topological-sort = "0.2.2"
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.61.0**.
-At least the last 3 versions of stable Rust are supported at any given time.
+The minimum supported Rust version is **Rust 1.85.0**.
 
 While a crate is pre-release status (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,9 @@
+pre-release-replacements = [
+  { file = "CHANGELOG.md", search = "Unreleased", replace = "{{version}}" },
+  { file = "CHANGELOG.md", search = "/commits/HEAD", replace = "/commits/{{tag_name}}", min = 0, max = 1 },
+  { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", min = 0, max = 1 },
+  { file = "CHANGELOG.md", search = "ReleaseDate", replace = "{{date}}" },
+  { file = "CHANGELOG.md", search = "<!-- next-header -->", replace = "<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly = 1 },
+  { file = "CHANGELOG.md", search = "<!-- next-url -->", replace = "<!-- next-url -->\n[Unreleased]: https://github.com/gifnksm/topological-sort-rs/compare/{{tag_name}}...HEAD", exactly = 1 },
+  { file = "README.md", search = "topological-sort = \"[0-9\\.]+\"", replace = "{{crate_name}} = \"{{version}}\"" },
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,24 +7,6 @@
 
 //! Performs topological sorting.
 
-#![warn(bad_style)]
-#![warn(missing_copy_implementations)]
-#![warn(missing_debug_implementations)]
-#![warn(missing_docs)]
-#![warn(trivial_casts)]
-#![warn(trivial_numeric_casts)]
-#![warn(unused)]
-#![warn(unused_extern_crates)]
-#![warn(unused_import_braces)]
-#![warn(unused_qualifications)]
-#![warn(clippy::if_not_else)]
-#![warn(clippy::invalid_upcast_comparisons)]
-#![warn(clippy::items_after_statements)]
-#![warn(clippy::mut_mut)]
-#![warn(clippy::never_loop)]
-#![warn(clippy::nonminimal_bool)]
-#![warn(clippy::used_underscore_binding)]
-
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -122,7 +104,6 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
             }
             Entry::Occupied(e) => {
                 if !e.into_mut().succ.insert(succ.clone()) {
-                    println!("Already registered");
                     // Already registered
                     return false;
                 }


### PR DESCRIPTION
## Summary
- add `CHANGELOG.md` in Keep a Changelog format with historical release notes and current unreleased changes
- align release and lint configuration with the new changelog workflow by adding `release.toml` and `.markdownlint.json`, and moving lint settings into `Cargo.toml`
- update the documented MSRV to Rust 1.85.0 and remove stray stdout output on duplicate dependency registration

## Notes
- The new changelog documents tagged releases from `0.0.2` through `0.2.2` by reviewing tag-to-tag diffs rather than relying only on commit subjects.
- The `Unreleased` section is intended to cover all unreleased changes since `v0.2.2`, including changes already committed on `master` plus the adjustments in this branch.
- Changelog entries separate user-facing changes from project and tooling maintenance details where possible.

## Validation
- `cargo test`
- Markdown diagnostics for `CHANGELOG.md`
- Markdown diagnostics for `README.md`