### PR TITLE
Adopt Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "topological-sort"
 version = "0.2.2"
-edition = "2018"
+edition = "2024"
 rust-version = "1.85.0"
 description = "Performs topological sorting."
 documentation = "https://docs.rs/topological-sort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::{
     cmp::Ordering,
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     fmt,
     hash::Hash,
     iter::FromIterator,


### PR DESCRIPTION
## Summary
- switch the crate edition from Rust 2018 to Rust 2024 in `Cargo.toml`
- keep `rust-version = "1.85.0"`, which matches the minimum compiler version that supports edition 2024
- include the `cargo fmt` import reorder in `src/lib.rs` that results from the edition/style change
- leave `CHANGELOG.md` unchanged because `Unreleased` already includes the Rust 1.85 / MSRV update, and there is no additional user-visible behavior change in this PR

## Validation
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Impact
- no API or behavior changes expected
- build now explicitly targets edition 2024
- source formatting reflects the Rust 2024 formatting behavior