### PR TITLE
Add Cargo keywords and categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ documentation = "https://docs.rs/topological-sort"
 readme = "README.md"
 repository = "https://github.com/gifnksm/topological-sort-rs"
 license = "MIT OR Apache-2.0"
+keywords = ["dag", "dependency", "graph", "topological", "toposort"]
+categories = ["algorithms", "data-structures"]
 
 [package.metadata.cargo-sync-rdme.badge.badges]
 maintenance = true


### PR DESCRIPTION
## Summary
- add Cargo metadata keywords to improve crates.io discoverability
- declare the crate categories in `Cargo.toml`

## Details
Added the following `keywords`:
- `dag`
- `dependency`
- `graph`
- `topological`
- `toposort`

## Validation
- `cargo test --locked`

## Notes
- No `CHANGELOG.md` entry was added because this change only updates crate metadata and does not affect the public API or runtime behavior.
- GitHub repository topics are a separate repository setting and are not changed by this PR.