### PR TITLE
Remove tuple conversion for DependencyLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new edge and `false` when the edge already existed.
-* Raised the minimum supported Rust version to Rust 1.85.0 and updated CI to test against it, in line with the project's 0.x MSRV policy.
+* **(Breaking Change)** Removed `impl From<(T, T)> for DependencyLink<T>`.
+  The tuple order was the inverse of `TopologicalSort::add_dependency(prec,
+  succ)` and `DependencyLink { prec, succ }`, which made it easy to invert an
+  edge by mistake.
+
+  Migrate tuple-based construction to explicit field names:
+  * Replace `ts.add_link((succ, prec).into())` with
+    `ts.add_link(DependencyLink { prec, succ })`.
+  * Replace `DependencyLink::from((succ, prec))` with
+    `DependencyLink { prec, succ }`.
+  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with
+    `.map(|(succ, prec)| DependencyLink { prec, succ })`.
+* Raised the minimum supported Rust version to Rust 1.85.0.
 * Updated project maintenance and tooling.
   * Added regression tests covering self-dependencies and cycles created with `DependencyLink`.
   * Added repository-wide configuration in `.editorconfig`, `.gitattributes`, `.markdownlintignore`, `codecov.yml`, `deny.toml`, and `justfile`, expanded Cargo metadata in `Cargo.toml` for linting and README synchronization, and moved release automation into `release.toml`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,10 +95,8 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
         P: Into<T>,
         S: Into<T>,
     {
-        self.add_dependency_impl(prec.into(), succ.into())
-    }
-
-    fn add_dependency_impl(&mut self, prec: T, succ: T) -> bool {
+        let prec = prec.into();
+        let succ = succ.into();
         match self.top.entry(prec) {
             Entry::Vacant(e) => {
                 let mut dep = Dependency::new();
@@ -240,15 +238,6 @@ pub struct DependencyLink<T> {
     pub prec: T,
     /// The element which depends on `prec`.
     pub succ: T,
-}
-
-impl<T> From<(T, T)> for DependencyLink<T> {
-    fn from(tuple: (T, T)) -> Self {
-        DependencyLink {
-            succ: tuple.0,
-            prec: tuple.1,
-        }
-    }
 }
 
 impl<T: Eq + Hash + Clone> FromIterator<DependencyLink<T>> for TopologicalSort<T> {


### PR DESCRIPTION
## Summary

Remove `impl From<(T, T)> for DependencyLink<T>` and document the migration path in the changelog.

## Why

`TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }` both use predecessor-then-successor ordering, but the tuple conversion interpreted `(succ, prec)` in the opposite order. Because both values have the same type, this made it easy to invert an edge by mistake while still compiling successfully.

This is an intentional breaking change to prefer explicit, self-documenting construction over an ambiguous tuple conversion.

## What changed

- removed `impl From<(T, T)> for DependencyLink<T>`
- inlined the small helper used by `add_dependency`
- added changelog guidance for migrating tuple-based code

## Migration

Replace tuple-based construction with explicit field names:

```rust
// before
ts.add_link((succ, prec).into());
let link = DependencyLink::from((succ, prec));
let links = pairs.into_iter().map(DependencyLink::from);

// after
ts.add_link(DependencyLink { prec, succ });
let link = DependencyLink { prec, succ };
let links = pairs
    .into_iter()
    .map(|(succ, prec)| DependencyLink { prec, succ });
```

## Validation

- `cargo test`
