### PR TITLE
Refine TopologicalSort debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with
     `.map(|(succ, prec)| DependencyLink { prec, succ })`.
 * Raised the minimum supported Rust version to Rust 1.85.0.
+* Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
 * Updated project maintenance and tooling.
   * Added regression tests covering self-dependencies and cycles created with `DependencyLink`.
   * Added repository-wide configuration in `.editorconfig`, `.gitattributes`, `.markdownlintignore`, `codecov.yml`, `deny.toml`, and `justfile`, expanded Cargo metadata in `Cargo.toml` for linting and README synchronization, and moved release automation into `release.toml`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     iter::FromIterator,
 };
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Dependency<T> {
     num_prec: usize,
     succ: HashSet<T>,
@@ -258,15 +258,11 @@ impl<T: Hash + Eq + Clone> Iterator for TopologicalSort<T> {
     }
 }
 
-impl<T: fmt::Debug + Hash + Eq> fmt::Debug for Dependency<T> {
+impl<T: fmt::Debug> fmt::Debug for TopologicalSort<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "prec={}, succ={:?}", self.num_prec, self.succ)
-    }
-}
-
-impl<T: fmt::Debug + Hash + Eq + Clone> fmt::Debug for TopologicalSort<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.top)
+        f.debug_map()
+            .entries(self.top.iter().map(|(k, dep)| (k, &dep.succ)))
+            .finish()
     }
 }
 
@@ -371,7 +367,6 @@ mod test {
         ts.add_dependency("water", "bucket");
         assert_eq!(ts.pop(), Some("stone"));
         assert!(ts.pop().is_none());
-        println!("{:?}", ts);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- adjust `TopologicalSort<T>` debug output to use a more collection-like representation
- expose successor sets in the debug view instead of the internal `Dependency` formatting
- relax the `Debug` implementation bounds to require only `T: Debug`
- note the debug output change in `CHANGELOG.md`

## Validation

- `cargo test`
- `diagnostics` on `CHANGELOG.md`

## Impact

This changes the human-readable `Debug` output of `TopologicalSort<T>`, but does not change the public API surface or runtime behavior of the sorter itself.