### PR TITLE
Strengthen linting and add must_use annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,24 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new edge and `false` when the edge already existed.
+* **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new dependency link and `false` when that link already existed.
 * **(Breaking Change)** Removed `impl From<(T, T)> for DependencyLink<T>`.
-  The tuple order was the inverse of `TopologicalSort::add_dependency(prec,
-  succ)` and `DependencyLink { prec, succ }`, which made it easy to invert an
-  edge by mistake.
+  The tuple order was the inverse of `TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }`, which made it easy to invert a dependency link by mistake.
 
   Migrate tuple-based construction to explicit field names:
-  * Replace `ts.add_link((succ, prec).into())` with
-    `ts.add_link(DependencyLink { prec, succ })`.
-  * Replace `DependencyLink::from((succ, prec))` with
-    `DependencyLink { prec, succ }`.
-  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with
-    `.map(|(succ, prec)| DependencyLink { prec, succ })`.
+
+  * Replace `ts.add_link((succ, prec).into())` with `ts.add_link(DependencyLink { prec, succ })`.
+  * Replace `DependencyLink::from((succ, prec))` with `DependencyLink { prec, succ }`.
+  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
+
 * Raised the minimum supported Rust version to Rust 1.85.0.
 * Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
+* Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_all()`, which may produce new warnings when their return values are ignored.
 * Updated project maintenance and tooling.
   * Added regression tests covering self-dependencies and cycles created with `DependencyLink`.
-  * Added repository-wide configuration in `.editorconfig`, `.gitattributes`, `.markdownlintignore`, `codecov.yml`, `deny.toml`, and `justfile`, expanded Cargo metadata in `Cargo.toml` for linting and README synchronization, and moved release automation into `release.toml`.
+  * Added repository-wide configuration in `.editorconfig`, `.gitattributes`, `.markdownlintignore`, `codecov.yml`, `deny.toml`, and `justfile`, expanded Cargo metadata in `Cargo.toml` for linting and README synchronization, tightened the Clippy configuration with additional `cargo` and `restriction` lints, and moved release automation into `release.toml`.
   * Split GitHub Actions automation into dedicated workflows in `.github/workflows/ci.yml`, `.github/workflows/cd.yml`, `.github/workflows/audit.yml`, and `.github/workflows/update-deps.yml`, updated `.github/dependabot.yml`, and expanded checks across Linux, macOS, and Windows.
   * Started tracking `Cargo.lock`.
   * Changed the repository's default branch from `master` to `main` and updated related automation and README badges.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,12 @@ quickcheck_macros = "1.2.0"
 maintenance = { status = "passively-maintained" }
 
 [lints.clippy]
-if_not_else = "warn"
-invalid_upcast_comparisons = "warn"
-items_after_statements = "warn"
-mut_mut = "warn"
-never_loop = "warn"
-nonminimal_bool = "warn"
-used_underscore_binding = "warn"
+cargo = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+
+# Restriction group
+get_unwrap = "warn"
+inline_trait_bounds = "warn"
 
 [lints.rust]
 missing_copy_implementations = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,18 +68,21 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
     /// assert!(ts.pop_all().is_empty());
     /// ```
     #[inline]
+    #[must_use]
     pub fn new() -> TopologicalSort<T> {
-        Default::default()
+        Self::default()
     }
 
     /// Returns the number of elements in the `TopologicalSort`.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.top.len()
     }
 
     /// Returns true if the `TopologicalSort` contains no elements.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.top.is_empty()
     }
@@ -177,6 +180,7 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
 
     /// Return a reference to the first item that does not depend on any other items, or `None` if
     /// there is no such item.
+    #[must_use]
     pub fn peek(&self) -> Option<&T> {
         self.top
             .iter()
@@ -187,6 +191,7 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
 
     /// Return a vector of references to all items that do not depend on any other items, or an
     /// empty vector if there are no such items.
+    #[must_use]
     pub fn peek_all(&self) -> Vec<&T> {
         self.top
             .iter()
@@ -209,7 +214,10 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
 }
 
 impl<T: PartialOrd + Eq + Hash + Clone> FromIterator<T> for TopologicalSort<T> {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> TopologicalSort<T> {
+    fn from_iter<I>(iter: I) -> TopologicalSort<T>
+    where
+        I: IntoIterator<Item = T>,
+    {
         let mut top = TopologicalSort::new();
         let mut seen = Vec::<T>::default();
         for item in iter {
@@ -241,7 +249,10 @@ pub struct DependencyLink<T> {
 }
 
 impl<T: Eq + Hash + Clone> FromIterator<DependencyLink<T>> for TopologicalSort<T> {
-    fn from_iter<I: IntoIterator<Item = DependencyLink<T>>>(iter: I) -> TopologicalSort<T> {
+    fn from_iter<I>(iter: I) -> TopologicalSort<T>
+    where
+        I: IntoIterator<Item = DependencyLink<T>>,
+    {
         let mut top = TopologicalSort::new();
         for link in iter {
             top.add_link(link);
@@ -334,7 +345,7 @@ mod tests {
         fn check(result: &[i32], ts: &mut TopologicalSort<i32>) {
             let l = ts.len();
             let mut v = ts.pop_all();
-            v.sort();
+            v.sort_unstable();
             assert_eq!(result, &v[..]);
             assert_eq!(l - result.len(), ts.len());
         }
@@ -441,7 +452,7 @@ mod tests {
             toposort.add_dependency(inp, op);
         }
         while let Some(x) = toposort.pop() {
-            for dep in deps.get(&x).unwrap().iter() {
+            for dep in &deps[&x] {
                 assert!(marked[*dep]);
             }
             marked[x] = true;
@@ -461,9 +472,9 @@ mod tests {
                         let inps = ret.get_mut(&k).unwrap();
                         inps.extend(v.into_iter());
                     }
-                    for (k, vs) in ret.iter() {
-                        for k2 in vs.iter() {
-                            for v2 in ret.get(k2).unwrap().iter() {
+                    for (k, vs) in &ret {
+                        for k2 in vs {
+                            for v2 in &ret[k2] {
                                 if !vs.contains(v2) {
                                     new_to_add
                                         .entry(*k)


### PR DESCRIPTION
## Summary
- switch the crate from a handful of individually configured Clippy lints to the broader `cargo` and `pedantic` lint groups
- add `restriction` lints for `get_unwrap` and `inline_trait_bounds`
- add `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_all()`
- update `src/lib.rs` and tests to satisfy the stricter lint set
- update `CHANGELOG.md` so the Unreleased notes reflect both the lint changes and the new `#[must_use]` annotations

## Motivation
This keeps the lint configuration stricter and easier to maintain while also documenting the user-visible warning changes from the new `#[must_use]` annotations.

## Validation
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `diagnostics` on `CHANGELOG.md`

## User-visible impact
No runtime behavior changes are intended, but ignoring the return values of `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, or `peek_all()` may now produce warnings.

## Risk
Low. The code changes are limited to lint-driven cleanup and public API annotations that affect warnings rather than behavior.