### PR TITLE
Remove FromIterator for plain items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new dependency link and `false` when that link already existed.
-* **(Breaking Change)** Removed `impl From<(T, T)> for DependencyLink<T>`.
-  The tuple order was the inverse of `TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }`, which made it easy to invert a dependency link by mistake.
-
-  Migrate tuple-based construction to explicit field names:
-
-  * Replace `ts.add_link((succ, prec).into())` with `ts.add_link(DependencyLink { prec, succ })`.
-  * Replace `DependencyLink::from((succ, prec))` with `DependencyLink { prec, succ }`.
-  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
-
 * Raised the minimum supported Rust version to Rust 1.85.0.
 * Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
 * Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_all()`, which may produce new warnings when their return values are ignored.
@@ -34,6 +25,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Split GitHub Actions automation into dedicated workflows in `.github/workflows/ci.yml`, `.github/workflows/cd.yml`, `.github/workflows/audit.yml`, and `.github/workflows/update-deps.yml`, updated `.github/dependabot.yml`, and expanded checks across Linux, macOS, and Windows.
   * Started tracking `Cargo.lock`.
   * Changed the repository's default branch from `master` to `main` and updated related automation and README badges.
+
+### Removed
+
+* **(Breaking Change)** Removed `impl From<(T, T)> for DependencyLink<T>`.
+  The tuple order was the inverse of `TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }`, which made it easy to invert a dependency link by mistake.
+
+  Migration notes:
+
+  * Replace `ts.add_link((succ, prec).into())` with `ts.add_link(DependencyLink { prec, succ })`.
+  * Replace `DependencyLink::from((succ, prec))` with `DependencyLink { prec, succ }`.
+  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
+
+* **(Breaking Change)** Removed `impl FromIterator<T> for TopologicalSort<T>`.
+  The implementation compared each item with all previously seen items using `partial_cmp()`, added dependency links for comparable pairs, and ignored equal or incomparable pairs, so the work grew as `n^2` with the length of the input iterator.
+  This was a poor fit for `collect()`: a call like `items.into_iter().collect::<TopologicalSort<_>>()` does not suggest pairwise comparison against all previously seen items or `n^2` work over the input.
+
+  Migration notes:
+
+  * There is no direct replacement for `items.into_iter().collect::<TopologicalSort<_>>()`.
+  * If `partial_cmp()` defines a total order for your values and you only needed to iterate them in order, collect them into a `Vec` and sort it directly instead of using `TopologicalSort`.
+  * If you intended to model dependency links, construct the graph explicitly with `TopologicalSort::new()` plus `insert()`, `add_dependency()`, and/or `add_link()`.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
-    cmp::Ordering,
     collections::{HashMap, HashSet, hash_map::Entry},
     fmt,
     hash::Hash,
@@ -213,32 +212,6 @@ impl<T: Hash + Eq + Clone> TopologicalSort<T> {
     }
 }
 
-impl<T: PartialOrd + Eq + Hash + Clone> FromIterator<T> for TopologicalSort<T> {
-    fn from_iter<I>(iter: I) -> TopologicalSort<T>
-    where
-        I: IntoIterator<Item = T>,
-    {
-        let mut top = TopologicalSort::new();
-        let mut seen = Vec::<T>::default();
-        for item in iter {
-            top.insert(item.clone());
-            for seen_item in seen.iter().cloned() {
-                match seen_item.partial_cmp(&item) {
-                    Some(Ordering::Less) => {
-                        top.add_dependency(seen_item, item.clone());
-                    }
-                    Some(Ordering::Greater) => {
-                        top.add_dependency(item.clone(), seen_item);
-                    }
-                    _ => (),
-                }
-            }
-            seen.push(item);
-        }
-        top
-    }
-}
-
 /// A link between two items in a sort.
 #[derive(Copy, Clone, Debug)]
 pub struct DependencyLink<T> {
@@ -312,19 +285,6 @@ mod tests {
             succ: "sharp",
         }));
         assert_eq!(ts.len(), 2);
-    }
-
-    #[test]
-    fn from_iter_makes_smaller_elements_precede_larger_ones() {
-        let t = vec![4, 3, 3, 5, 7, 6, 8];
-        let mut ts = TopologicalSort::<i32>::from_iter(t);
-        assert_eq!(Some(3), ts.next());
-        assert_eq!(Some(4), ts.next());
-        assert_eq!(Some(5), ts.next());
-        assert_eq!(Some(6), ts.next());
-        assert_eq!(Some(7), ts.next());
-        assert_eq!(Some(8), ts.next());
-        assert_eq!(None, ts.next());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove `impl FromIterator<T> for TopologicalSort<T>`
- remove the test that exercised the implicit item-ordering behavior
- document the breaking change and migration guidance in `CHANGELOG.md`

## Why

Collecting plain items into `TopologicalSort` implicitly compared each item with all previously seen items and added dependency links for comparable pairs. That behavior was not obvious from `collect::<TopologicalSort<_>>()`, and it performed `n^2` work over the input.

When callers only need iteration in sorted order, collecting into a `Vec` and sorting is clearer and more efficient. Callers that want dependency relationships can continue to build them explicitly with `insert()`, `add_dependency()`, `add_link()`, or `DependencyLink<T>`.

## Validation

- `cargo test`

## Impact

This is a breaking change for callers relying on `items.into_iter().collect::<TopologicalSort<_>>()`. There is no direct replacement for the removed implementation.
