### PR TITLE
Implement Extend for dependency links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Implemented `Extend<DependencyLink<T>>` for `TopologicalSort<T>`, allowing dependency links to be appended with `extend()`.
 * Added `CHANGELOG.md`.
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,10 +236,22 @@ where
         I: IntoIterator<Item = DependencyLink<T>>,
     {
         let mut top = TopologicalSort::new();
-        for link in iter {
-            top.add_link(link);
-        }
+        top.extend(iter);
         top
+    }
+}
+
+impl<T> Extend<DependencyLink<T>> for TopologicalSort<T>
+where
+    T: Eq + Hash + Clone,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = DependencyLink<T>>,
+    {
+        for link in iter {
+            self.add_link(link);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- implement `Extend<DependencyLink<T>>` for `TopologicalSort<T>`
- make `FromIterator<DependencyLink<T>>` reuse `extend()`
- document the new `extend()` support in `CHANGELOG.md`

## Validation

- `cargo test`

## Notes

- no behavior change beyond adding the new `Extend`-based construction path
