### PR TITLE
Replace Iterator impl with pop_iter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Implemented `Extend<DependencyLink<T>>` for `TopologicalSort<T>`, allowing dependency links to be appended with `extend()`.
+* Added `TopologicalSort::pop_iter()`, which returns a `PopIter<'_, T>` that repeatedly calls `pop()`.
 * Added `CHANGELOG.md`.
 
 ### Changed
@@ -39,14 +40,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
 
 * **(Breaking Change)** Removed `impl FromIterator<T> for TopologicalSort<T>`.
-  The implementation compared each item with all previously seen items using `partial_cmp()`, added dependency links for comparable pairs, and ignored equal or incomparable pairs, so the work grew as `n^2` with the length of the input iterator.
-  This was a poor fit for `collect()`: a call like `items.into_iter().collect::<TopologicalSort<_>>()` does not suggest pairwise comparison against all previously seen items or `n^2` work over the input.
+  `TopologicalSort::from_iter(iter)` or `iter.collect::<TopologicalSort<T>>()` compared each item with all previously seen items using `partial_cmp()` and inferred dependency links from every comparable pair.
+  That behavior was not intuitive for `from_iter()`, which readers could reasonably expect to just gather items or to derive relationships only from something more local such as adjacent pairs.
+  It also made `from_iter()` unexpectedly `O(n^2)` instead of the `O(n)` work that a collection-style operation usually suggests.
 
   Migration notes:
 
   * There is no direct replacement for `items.into_iter().collect::<TopologicalSort<_>>()`.
   * If `partial_cmp()` defines a total order for your values and you only needed to iterate them in order, collect them into a `Vec` and sort it directly instead of using `TopologicalSort`.
   * If you intended to model dependency links, construct the graph explicitly with `TopologicalSort::new()` plus `insert()`, `add_dependency()`, and/or `add_link()`.
+
+* **(Breaking Change)** Removed `impl Iterator for TopologicalSort<T>`.
+  Destructive iteration now requires an explicit `TopologicalSort::pop_iter()` call.
+  Iterating `TopologicalSort` removes items from the sort.
+  Implementing `Iterator` for `TopologicalSort` exposed methods such as `count()`, `find()`, and `filter()` directly on the sort itself.
+  On `TopologicalSort`, those methods look like inspection or search operations, even though calling them could destructively advance or consume the sort.
+  Requiring `pop_iter()` makes that destructive step explicit.
+
+  Migration notes:
+
+  * Replace `ts.next()` with `ts.pop()` when consuming one item at a time.
+  * Replace iteration through `TopologicalSort` itself with `ts.pop_iter()`.
+  * Replace direct iterator adapter calls on `TopologicalSort` with calls on `ts.pop_iter()` instead.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     collections::{HashMap, HashSet, hash_map::Entry},
     fmt,
     hash::Hash,
-    iter::FromIterator,
+    iter::{FromIterator, FusedIterator},
 };
 
 #[derive(Clone, Debug)]
@@ -166,6 +166,31 @@ where
         })
     }
 
+    /// Returns an iterator that repeatedly calls [`pop`](Self::pop).
+    ///
+    /// Each call to [`Iterator::next`] removes one item from the sort.
+    ///
+    /// The iterator ends when the sort becomes empty or when no item can be popped because the
+    /// remaining items contain a cycle.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// ts.add_dependency(1, 2);
+    /// ts.add_dependency(2, 3);
+    ///
+    /// let mut it = ts.pop_iter();
+    /// assert_eq!(Some(1), it.next());
+    /// assert_eq!(Some(2), it.next());
+    /// drop(it);
+    ///
+    /// assert_eq!(Some(3), ts.pop());
+    /// ```
+    pub fn pop_iter(&mut self) -> PopIter<'_, T> {
+        PopIter { ts: self }
+    }
+
     /// Removes all items that are not depended on by any other items and returns it, or empty
     /// vector if there are no such items.
     ///
@@ -255,16 +280,31 @@ where
     }
 }
 
-impl<T> Iterator for TopologicalSort<T>
+/// An iterator over items popped from a [`TopologicalSort`].
+///
+/// This struct is created by [`TopologicalSort::pop_iter`].
+#[derive(Debug)]
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+pub struct PopIter<'a, T> {
+    ts: &'a mut TopologicalSort<T>,
+}
+
+impl<T> Iterator for PopIter<'_, T>
 where
-    T: Hash + Eq + Clone,
+    T: Clone + Eq + Hash,
 {
     type Item = T;
 
-    fn next(&mut self) -> Option<T> {
-        self.pop()
+    fn next(&mut self) -> Option<Self::Item> {
+        self.ts.pop()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(self.ts.len()))
     }
 }
+
+impl<T> FusedIterator for PopIter<'_, T> where T: Clone + Eq + Hash {}
 
 impl<T> fmt::Debug for TopologicalSort<T>
 where
@@ -315,16 +355,40 @@ mod tests {
     }
 
     #[test]
-    fn next_returns_elements_in_topological_order() {
+    fn pop_iter_iterates_all_elements_in_topological_order() {
         let mut ts = TopologicalSort::<i32>::new();
         ts.add_dependency(1, 2);
         ts.add_dependency(2, 3);
         ts.add_dependency(3, 4);
-        assert_eq!(Some(1), ts.next());
-        assert_eq!(Some(2), ts.next());
-        assert_eq!(Some(3), ts.next());
-        assert_eq!(Some(4), ts.next());
-        assert_eq!(None, ts.next());
+        ts.add_dependency(4, 5);
+        ts.add_dependency(5, 6);
+        let mut it = ts.pop_iter();
+        assert_eq!(Some(1), it.next());
+        assert_eq!(Some(2), it.next());
+        assert_eq!(Some(3), it.next());
+        assert_eq!(Some(4), it.next());
+        assert_eq!(Some(5), it.next());
+        assert_eq!(Some(6), it.next());
+        assert_eq!(None, it.next());
+        assert_eq!(None, it.next());
+    }
+
+    #[test]
+    fn pop_iter_stops_on_a_cycle() {
+        let mut ts = TopologicalSort::<i32>::new();
+        ts.add_dependency(1, 2);
+        ts.add_dependency(2, 3);
+        ts.add_dependency(3, 4);
+        ts.add_dependency(4, 5);
+        ts.add_dependency(5, 5);
+        ts.add_dependency(5, 6);
+        let mut it = ts.pop_iter();
+        assert_eq!(Some(1), it.next());
+        assert_eq!(Some(2), it.next());
+        assert_eq!(Some(3), it.next());
+        assert_eq!(Some(4), it.next());
+        assert_eq!(None, it.next());
+        assert_eq!(None, it.next());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove `impl Iterator for TopologicalSort<T>`
- add `TopologicalSort::pop_iter()` and `PopIter<'_, T>` for explicit destructive iteration
- update tests and changelog for the new iteration API

## Why

Iterating `TopologicalSort` is destructive. Having `TopologicalSort` implement `Iterator` exposed iterator adapters such as `count()`, `find()`, and `filter()` directly on the sort itself, even though those operations could advance or consume the sort. Requiring `pop_iter()` makes that destructive step explicit.

## Validation

- `cargo test`

## Impact

This is a breaking change.

- replace `ts.next()` with `ts.pop()` when consuming one item at a time
- replace iteration through `TopologicalSort` itself with `ts.pop_iter()`
- replace direct iterator adapter calls on `TopologicalSort` with calls on `ts.pop_iter()` instead