### PR TITLE
Rename pop_all and peek_all to batch APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new dependency link and `false` when that link already existed.
 * Raised the minimum supported Rust version to Rust 1.85.0.
 * Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
-* Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_all()`, which may produce new warnings when their return values are ignored.
+* Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_batch()`, which may produce new warnings when their return values are ignored.
+* **(Breaking Change)** Renamed `TopologicalSort::pop_all()` to `TopologicalSort::pop_batch()` and `TopologicalSort::peek_all()` to `TopologicalSort::peek_batch()`.
+  * **Rationale:**
+    The old names were easy to read as exhausting the sort or inspecting every item that could ever be popped.
+    In practice, both methods only operated on the current batch of items that had no remaining dependencies at the time of the call.
+    The new names make that batch-oriented behavior explicit and help avoid using a single `pop_all()` call as a cycle check.
+  * **Migration notes:**
+    * Replace `ts.pop_all()` with `ts.pop_batch()`.
+    * Replace `ts.peek_all()` with `ts.peek_batch()`.
+    * If you intended to keep popping until no more progress is possible, use `ts.pop_iter()` instead, for example `let items: Vec<_> = ts.pop_iter().collect();`.
 * Updated project maintenance and tooling.
   * Added regression tests covering self-dependencies and cycles created with `DependencyLink`.
   * Added repository-wide configuration in `.editorconfig`, `.gitattributes`, `.markdownlintignore`, `codecov.yml`, `deny.toml`, and `justfile`, expanded Cargo metadata in `Cargo.toml` for linting and README synchronization, tightened the Clippy configuration with additional `cargo` and `restriction` lints, and moved release automation into `release.toml`.
@@ -31,37 +40,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 * **(Breaking Change)** Removed `impl From<(T, T)> for DependencyLink<T>`.
-  The tuple order was the inverse of `TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }`, which made it easy to invert a dependency link by mistake.
-
-  Migration notes:
-
-  * Replace `ts.add_link((succ, prec).into())` with `ts.add_link(DependencyLink { prec, succ })`.
-  * Replace `DependencyLink::from((succ, prec))` with `DependencyLink { prec, succ }`.
-  * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
-
+  * **Rationale:**
+    The tuple order was the inverse of `TopologicalSort::add_dependency(prec, succ)` and `DependencyLink { prec, succ }`, which made it easy to invert a dependency link by mistake.
+  * **Migration notes:**
+    * Replace `ts.add_link((succ, prec).into())` with `ts.add_link(DependencyLink { prec, succ })`.
+    * Replace `DependencyLink::from((succ, prec))` with `DependencyLink { prec, succ }`.
+    * Replace `.map(DependencyLink::from)` on `(succ, prec)` tuples with `.map(|(succ, prec)| DependencyLink { prec, succ })`.
 * **(Breaking Change)** Removed `impl FromIterator<T> for TopologicalSort<T>`.
-  `TopologicalSort::from_iter(iter)` or `iter.collect::<TopologicalSort<T>>()` compared each item with all previously seen items using `partial_cmp()` and inferred dependency links from every comparable pair.
-  That behavior was not intuitive for `from_iter()`, which readers could reasonably expect to just gather items or to derive relationships only from something more local such as adjacent pairs.
-  It also made `from_iter()` unexpectedly `O(n^2)` instead of the `O(n)` work that a collection-style operation usually suggests.
-
-  Migration notes:
-
-  * There is no direct replacement for `items.into_iter().collect::<TopologicalSort<_>>()`.
-  * If `partial_cmp()` defines a total order for your values and you only needed to iterate them in order, collect them into a `Vec` and sort it directly instead of using `TopologicalSort`.
-  * If you intended to model dependency links, construct the graph explicitly with `TopologicalSort::new()` plus `insert()`, `add_dependency()`, and/or `add_link()`.
-
+  * **Rationale:**
+    `TopologicalSort::from_iter(iter)` or `iter.collect::<TopologicalSort<T>>()` compared each item with all previously seen items using `partial_cmp()` and inferred dependency links from every comparable pair.
+    That behavior was not intuitive for `from_iter()`, which readers could reasonably expect to just gather items or to derive relationships only from something more local such as adjacent pairs.
+    It also made `from_iter()` unexpectedly `O(n^2)` instead of the `O(n)` work that a collection-style operation usually suggests.
+  * **Migration notes:**
+    * There is no direct replacement for `items.into_iter().collect::<TopologicalSort<_>>()`.
+    * If `partial_cmp()` defines a total order for your values and you only needed to iterate them in order, collect them into a `Vec` and sort it directly instead of using `TopologicalSort`.
+    * If you intended to model dependency links, construct the graph explicitly with `TopologicalSort::new()` plus `insert()`, `add_dependency()`, and/or `add_link()`.
 * **(Breaking Change)** Removed `impl Iterator for TopologicalSort<T>`.
   Destructive iteration now requires an explicit `TopologicalSort::pop_iter()` call.
-  Iterating `TopologicalSort` removes items from the sort.
-  Implementing `Iterator` for `TopologicalSort` exposed methods such as `count()`, `find()`, and `filter()` directly on the sort itself.
-  On `TopologicalSort`, those methods look like inspection or search operations, even though calling them could destructively advance or consume the sort.
-  Requiring `pop_iter()` makes that destructive step explicit.
-
-  Migration notes:
-
-  * Replace `ts.next()` with `ts.pop()` when consuming one item at a time.
-  * Replace iteration through `TopologicalSort` itself with `ts.pop_iter()`.
-  * Replace direct iterator adapter calls on `TopologicalSort` with calls on `ts.pop_iter()` instead.
+  * **Rationale:**
+    Iterating `TopologicalSort` removes items from the sort.
+    Implementing `Iterator` for `TopologicalSort` exposed methods such as `count()`, `find()`, and `filter()` directly on the sort itself.
+    On `TopologicalSort`, those methods look like inspection or search operations, even though calling them could destructively advance or consume the sort.
+    Requiring `pop_iter()` makes that destructive step explicit.
+  * **Migration notes:**
+    * Replace `ts.next()` with `ts.pop()` when consuming one item at a time.
+    * Replace iteration through `TopologicalSort` itself with `ts.pop_iter()`.
+    * Replace direct iterator adapter calls on `TopologicalSort` with calls on `ts.pop_iter()` instead.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,21 +56,21 @@ where
     /// ts.add_dependency("stdio.h", "hello_world.o");
     /// ts.add_dependency("glibc.so", "hello_world");
     /// assert_eq!(vec!["glibc.so", "hello_world.c", "stdio.h"], {
-    ///     let mut v = ts.pop_all();
+    ///     let mut v = ts.pop_batch();
     ///     v.sort();
     ///     v
     /// });
     /// assert_eq!(vec!["hello_world.o"], {
-    ///     let mut v = ts.pop_all();
+    ///     let mut v = ts.pop_batch();
     ///     v.sort();
     ///     v
     /// });
     /// assert_eq!(vec!["hello_world"], {
-    ///     let mut v = ts.pop_all();
+    ///     let mut v = ts.pop_batch();
     ///     v.sort();
     ///     v
     /// });
-    /// assert!(ts.pop_all().is_empty());
+    /// assert!(ts.pop_batch().is_empty());
     /// ```
     #[inline]
     #[must_use]
@@ -156,10 +156,10 @@ where
         }
     }
 
-    /// Removes the item that is not depended on by any other items and returns it, or `None` if
-    /// there is no such item.
+    /// Removes one item that does not depend on any other remaining item and returns it, or
+    /// `None` if there is no such item.
     ///
-    /// If `pop` returns `None` and `len` is not 0, there is cyclic dependencies.
+    /// If `pop` returns `None` and `len` is not 0, the remaining items contain a cycle.
     pub fn pop(&mut self) -> Option<T> {
         self.peek().cloned().inspect(|key| {
             self.remove(key);
@@ -191,11 +191,16 @@ where
         PopIter { ts: self }
     }
 
-    /// Removes all items that are not depended on by any other items and returns it, or empty
-    /// vector if there are no such items.
+    /// Removes all items that do not depend on any other remaining item at the time of the call
+    /// and returns them, or an empty vector if there are no such items.
     ///
-    /// If `pop_all` returns an empty vector and `len` is not 0, there is cyclic dependencies.
-    pub fn pop_all(&mut self) -> Vec<T> {
+    /// Unlike [`pop_iter`](Self::pop_iter), this removes only the current batch of ready items. If
+    /// removing those items makes more items ready, they are returned by the next call to
+    /// `pop_batch`, not the current one.
+    ///
+    /// If `pop_batch` returns an empty vector and `len` is not 0, the remaining items contain a
+    /// cycle.
+    pub fn pop_batch(&mut self) -> Vec<T> {
         let keys = self
             .nodes
             .iter()
@@ -208,8 +213,8 @@ where
         keys
     }
 
-    /// Return a reference to the first item that does not depend on any other items, or `None` if
-    /// there is no such item.
+    /// Returns a reference to one item that does not depend on any other remaining item, or
+    /// `None` if there is no such item.
     #[must_use]
     pub fn peek(&self) -> Option<&T> {
         self.nodes
@@ -219,10 +224,12 @@ where
             .next()
     }
 
-    /// Return a vector of references to all items that do not depend on any other items, or an
-    /// empty vector if there are no such items.
+    /// Returns references to all items that do not depend on any other remaining item at the time
+    /// of the call, or an empty vector if there are no such items.
+    ///
+    /// This inspects only the current batch of ready items.
     #[must_use]
-    pub fn peek_all(&self) -> Vec<&T> {
+    pub fn peek_batch(&self) -> Vec<&T> {
         self.nodes
             .iter()
             .filter(|&(_, v)| v.num_prec == 0)
@@ -392,10 +399,10 @@ mod tests {
     }
 
     #[test]
-    fn pop_all_returns_all_currently_available_elements() {
+    fn pop_batch_returns_all_currently_available_elements() {
         fn check(result: &[i32], ts: &mut TopologicalSort<i32>) {
             let l = ts.len();
-            let mut v = ts.pop_all();
+            let mut v = ts.pop_batch();
             v.sort_unstable();
             assert_eq!(result, &v[..]);
             assert_eq!(l - result.len(), ts.len());


### PR DESCRIPTION
## Summary
- rename `TopologicalSort::pop_all()` to `TopologicalSort::pop_batch()`
- rename `TopologicalSort::peek_all()` to `TopologicalSort::peek_batch()`
- update rustdoc examples and method docs to clarify that these APIs operate on only the current batch of ready items
- document the breaking change and migration steps in `CHANGELOG.md`

## Motivation
`pop_all()` and `peek_all()` were easy to misread as exhausting the sort or inspecting every item that could ever be popped. In practice they only operate on the current batch of items with no remaining dependencies at the time of the call, so the new names make that behavior explicit.

## Validation
- `cargo test`

## Breaking change
- replace `ts.pop_all()` with `ts.pop_batch()`
- replace `ts.peek_all()` with `ts.peek_batch()`
- if you intended to keep popping until no more progress is possible, use `ts.pop_iter()` instead, for example `ts.pop_iter().collect::<Vec<_>>()`