### PR TITLE
Add remove API and expand docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Implemented `Extend<DependencyLink<T>>` for `TopologicalSort<T>`, allowing dependency links to be appended with `extend()`.
 * Added `TopologicalSort::pop_iter()`, which returns a `PopIter<'_, T>` that repeatedly calls `pop()`.
+* Added `TopologicalSort::remove()`, which removes a specified item only when it has no remaining dependencies.
 * Added `CHANGELOG.md`.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@
 <!-- cargo-sync-rdme ]] -->
 
 <!-- cargo-sync-rdme rustdoc [[ -->
-Performs topological sorting.
+A data structure for topological sorting.
+
+## Examples
+
+### Modeling Makefile-style dependencies
+
+This example reproduces a small `Makefile`. Each call to [`TopologicalSort::pop_batch`](https://docs.rs/topological-sort/0.2.2/topological_sort/TopologicalSort/fn.pop_batch.html)
+returns the next batch of files that can be built in parallel.
+
+````Makefile
+hello_world: hello_world.o libhello.so
+        gcc -o hello_world hello_world.o -lhello
+
+hello_world.o: hello_world.c hello.h
+        gcc -c -o hello_world.o hello_world.c
+````
 
 ````rust
 use topological_sort::TopologicalSort;
@@ -20,23 +35,118 @@ use topological_sort::TopologicalSort;
 let mut ts = TopologicalSort::<&str>::new();
 
 ts.add_dependency("hello_world.o", "hello_world");
+ts.add_dependency("libhello.so", "hello_world");
 ts.add_dependency("hello_world.c", "hello_world.o");
-ts.add_dependency("stdio.h", "hello_world.o");
-ts.add_dependency("glibc.so", "hello_world");
+ts.add_dependency("hello.h", "hello_world.o");
 
+// Source inputs with no remaining dependencies are ready first.
 let mut first_group = ts.pop_batch();
 first_group.sort();
-assert_eq!(first_group, ["glibc.so", "hello_world.c", "stdio.h"]);
+assert_eq!(first_group, ["hello.h", "hello_world.c", "libhello.so"]);
 
+// Building those inputs makes the object file ready.
 let mut second_group = ts.pop_batch();
 second_group.sort();
 assert_eq!(second_group, ["hello_world.o"]);
 
+// Finally, the executable itself becomes ready.
 let mut third_group = ts.pop_batch();
 third_group.sort();
 assert_eq!(third_group, ["hello_world"]);
 
 assert!(ts.pop_batch().is_empty());
+````
+
+### Detecting circular dependencies
+
+This example consumes a sort by repeatedly popping ready items. If any items remain afterward,
+the remaining subgraph contains a cycle.
+
+````rust
+use topological_sort::TopologicalSort;
+
+fn has_circular_dependency(mut ts: TopologicalSort<&str>) -> bool {
+    // Remove every item that can be processed.
+    ts.pop_iter().for_each(drop);
+    // Any remaining items must be blocked by a cycle.
+    !ts.is_empty()
+}
+
+let mut ts1 = TopologicalSort::<&str>::new();
+ts1.add_dependency("scissors", "rock");
+ts1.add_dependency("paper", "scissors");
+ts1.add_dependency("rock", "paper");
+
+let mut ts2 = TopologicalSort::<&str>::new();
+ts2.add_dependency("grass", "zebra");
+ts2.add_dependency("zebra", "lion");
+
+assert!(has_circular_dependency(ts1));
+assert!(!has_circular_dependency(ts2));
+````
+
+### Processing items one at a time
+
+This example repeatedly calls [`TopologicalSort::pop`](https://docs.rs/topological-sort/0.2.2/topological_sort/TopologicalSort/fn.pop.html) to process items as soon as each next
+item becomes ready.
+
+````rust
+use topological_sort::TopologicalSort;
+
+let mut ts = TopologicalSort::<&str>::new();
+ts.add_dependency("parse", "analyze");
+ts.add_dependency("analyze", "compile");
+
+while let Some(item) = ts.pop() {
+    process(item);
+}
+
+````
+
+### Using `TopologicalSort` in a task scheduler
+
+[`TopologicalSort`](https://docs.rs/topological-sort/0.2.2/topological_sort/struct.TopologicalSort.html) can serve as the dependency tracker inside a task
+scheduler. [`TopologicalSort::peek_batch`](https://docs.rs/topological-sort/0.2.2/topological_sort/TopologicalSort/fn.peek_batch.html) returns all tasks whose
+prerequisites are satisfied, and [`TopologicalSort::remove`](https://docs.rs/topological-sort/0.2.2/topological_sort/TopologicalSort/fn.remove.html) marks a
+completed task as done, which may make more tasks ready.
+
+Because [`TopologicalSort::peek_batch`](https://docs.rs/topological-sort/0.2.2/topological_sort/TopologicalSort/fn.peek_batch.html) does not remove tasks, a scheduler
+also needs to track which ready tasks are already running so it does not
+start them twice.
+
+````rust
+use std::collections::HashSet;
+
+use topological_sort::TopologicalSort;
+
+type Task = String;
+
+fn run_scheduler(tasks: TopologicalSort<Task>) {
+    let mut remaining_tasks = tasks;
+    let mut running_tasks = HashSet::new();
+
+    while !remaining_tasks.is_empty() {
+        // `peek_batch()` returns every task whose prerequisites are
+        // satisfied, including tasks that are already running.
+        let runnable_or_running_tasks = remaining_tasks.peek_batch();
+
+        let runnable_tasks = runnable_or_running_tasks
+            .into_iter()
+            .cloned()
+            .filter(|task| !running_tasks.contains(task))
+            .collect::<Vec<Task>>();
+
+        if !runnable_tasks.is_empty() {
+            start_tasks(&runnable_tasks);
+            running_tasks.extend(runnable_tasks);
+        }
+
+        // Wait for one running task to finish, then mark it complete.
+        let completed_task = wait_for_task_completion(&running_tasks);
+        remaining_tasks.remove(&completed_task);
+        running_tasks.remove(&completed_task);
+    }
+}
 ````
 <!-- cargo-sync-rdme ]] -->
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,19 @@
-//! Performs topological sorting.
+//! A data structure for topological sorting.
+//!
+//! # Examples
+//!
+//! ## Modeling Makefile-style dependencies
+//!
+//! This example reproduces a small `Makefile`. Each call to [`TopologicalSort::pop_batch`]
+//! returns the next batch of files that can be built in parallel.
+//!
+//! ```Makefile
+//! hello_world: hello_world.o libhello.so
+//!         gcc -o hello_world hello_world.o -lhello
+//!
+//! hello_world.o: hello_world.c hello.h
+//!         gcc -c -o hello_world.o hello_world.c
+//! ```
 //!
 //! ```rust
 //! use topological_sort::TopologicalSort;
@@ -6,28 +21,130 @@
 //! let mut ts = TopologicalSort::<&str>::new();
 //!
 //! ts.add_dependency("hello_world.o", "hello_world");
+//! ts.add_dependency("libhello.so", "hello_world");
 //! ts.add_dependency("hello_world.c", "hello_world.o");
-//! ts.add_dependency("stdio.h", "hello_world.o");
-//! ts.add_dependency("glibc.so", "hello_world");
+//! ts.add_dependency("hello.h", "hello_world.o");
 //!
+//! // Source inputs with no remaining dependencies are ready first.
 //! let mut first_group = ts.pop_batch();
 //! first_group.sort();
-//! assert_eq!(first_group, ["glibc.so", "hello_world.c", "stdio.h"]);
+//! assert_eq!(first_group, ["hello.h", "hello_world.c", "libhello.so"]);
 //!
+//! // Building those inputs makes the object file ready.
 //! let mut second_group = ts.pop_batch();
 //! second_group.sort();
 //! assert_eq!(second_group, ["hello_world.o"]);
 //!
+//! // Finally, the executable itself becomes ready.
 //! let mut third_group = ts.pop_batch();
 //! third_group.sort();
 //! assert_eq!(third_group, ["hello_world"]);
 //!
 //! assert!(ts.pop_batch().is_empty());
 //! ```
+//!
+//! ## Detecting circular dependencies
+//!
+//! This example consumes a sort by repeatedly popping ready items. If any items remain afterward,
+//! the remaining subgraph contains a cycle.
+//!
+//! ```rust
+//! use topological_sort::TopologicalSort;
+//!
+//! fn has_circular_dependency(mut ts: TopologicalSort<&str>) -> bool {
+//!     // Remove every item that can be processed.
+//!     ts.pop_iter().for_each(drop);
+//!     // Any remaining items must be blocked by a cycle.
+//!     !ts.is_empty()
+//! }
+//!
+//! let mut ts1 = TopologicalSort::<&str>::new();
+//! ts1.add_dependency("scissors", "rock");
+//! ts1.add_dependency("paper", "scissors");
+//! ts1.add_dependency("rock", "paper");
+//!
+//! let mut ts2 = TopologicalSort::<&str>::new();
+//! ts2.add_dependency("grass", "zebra");
+//! ts2.add_dependency("zebra", "lion");
+//!
+//! assert!(has_circular_dependency(ts1));
+//! assert!(!has_circular_dependency(ts2));
+//! ```
+//!
+//! ## Processing items one at a time
+//!
+//! This example repeatedly calls [`TopologicalSort::pop`] to process items as soon as each next
+//! item becomes ready.
+//!
+//! ```rust
+//! use topological_sort::TopologicalSort;
+//!
+//! # fn process(_item: &str) {}
+//! let mut ts = TopologicalSort::<&str>::new();
+//! ts.add_dependency("parse", "analyze");
+//! ts.add_dependency("analyze", "compile");
+//!
+//! # let mut processed = Vec::new();
+//! while let Some(item) = ts.pop() {
+//!     process(item);
+//! #   processed.push(item);
+//! }
+//!
+//! # assert_eq!(processed, vec!["parse", "analyze", "compile"]);
+//! ```
+//!
+//! ## Using `TopologicalSort` in a task scheduler
+//!
+//! [`TopologicalSort`] can serve as the dependency tracker inside a task
+//! scheduler. [`TopologicalSort::peek_batch`] returns all tasks whose
+//! prerequisites are satisfied, and [`TopologicalSort::remove`] marks a
+//! completed task as done, which may make more tasks ready.
+//!
+//! Because [`TopologicalSort::peek_batch`] does not remove tasks, a scheduler
+//! also needs to track which ready tasks are already running so it does not
+//! start them twice.
+//!
+//! ```rust
+//! use std::collections::HashSet;
+//!
+//! use topological_sort::TopologicalSort;
+//!
+//! type Task = String;
+//!
+//! # fn start_tasks(_tasks: &[Task]) {}
+//! # fn wait_for_task_completion(_running_tasks: &HashSet<Task>) -> Task { todo!() }
+//! fn run_scheduler(tasks: TopologicalSort<Task>) {
+//!     let mut remaining_tasks = tasks;
+//!     let mut running_tasks = HashSet::new();
+//!
+//!     while !remaining_tasks.is_empty() {
+//!         // `peek_batch()` returns every task whose prerequisites are
+//!         // satisfied, including tasks that are already running.
+//!         let runnable_or_running_tasks = remaining_tasks.peek_batch();
+//!
+//!         let runnable_tasks = runnable_or_running_tasks
+//!             .into_iter()
+//!             .cloned()
+//!             .filter(|task| !running_tasks.contains(task))
+//!             .collect::<Vec<Task>>();
+//!
+//!         if !runnable_tasks.is_empty() {
+//!             start_tasks(&runnable_tasks);
+//!             running_tasks.extend(runnable_tasks);
+//!         }
+//!
+//!         // Wait for one running task to finish, then mark it complete.
+//!         let completed_task = wait_for_task_completion(&running_tasks);
+//!         remaining_tasks.remove(&completed_task);
+//!         running_tasks.remove(&completed_task);
+//!     }
+//! }
+//! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
+    borrow::Borrow,
     collections::{HashMap, HashSet, hash_map::Entry},
     fmt,
     hash::Hash,
@@ -42,7 +159,7 @@ struct Node<T> {
 
 impl<T> Node<T>
 where
-    T: Hash + Eq,
+    T: Eq + Hash,
 {
     fn new() -> Node<T> {
         Node {
@@ -52,7 +169,7 @@ where
     }
 }
 
-/// Performs topological sorting.
+/// A data structure for topological sorting.
 ///
 /// See the [crate-level documentation](crate) for examples.
 #[derive(Clone)]
@@ -81,26 +198,39 @@ where
         Self::default()
     }
 
-    /// Returns the number of items in the `TopologicalSort`.
+    /// Returns the number of remaining items in the `TopologicalSort`.
+    ///
+    /// This counts all remaining items, including those that are not yet ready to pop.
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
         self.nodes.len()
     }
 
-    /// Returns true if the `TopologicalSort` contains no items.
+    /// Returns `true` if the `TopologicalSort` contains no remaining items.
     #[inline]
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.nodes.is_empty()
     }
 
-    /// Registers a dependency between two items.
+    /// Registers a dependency from `prec` to `succ`.
     ///
-    /// # Arguments
+    /// This means that `succ` depends on `prec`, so `prec` must be popped or removed
+    /// before `succ` becomes ready.
     ///
-    /// * `prec` - The item that appears before `succ` and is depended on by it.
-    /// * `succ` - The item that appears after `prec` and depends on it.
+    /// Returns `true` if this dependency link was newly added, or `false` if it was
+    /// already present.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// assert!(ts.add_dependency("compile", "link"));
+    ///
+    /// assert_eq!(ts.pop(), Some("compile"));
+    /// assert_eq!(ts.pop(), Some("link"));
+    /// ```
     pub fn add_dependency<P, S>(&mut self, prec: P, succ: S) -> bool
     where
         P: Into<T>,
@@ -136,15 +266,42 @@ where
     }
 
     /// Registers a dependency link.
+    ///
+    /// This means that `link.succ` depends on `link.prec`, so `link.prec` must be
+    /// popped or removed before `link.succ` becomes ready.
+    ///
+    /// Returns `true` if this dependency link was newly added, or `false` if it was
+    /// already present.
+    ///
+    /// ```rust
+    /// use topological_sort::{DependencyLink, TopologicalSort};
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// assert!(ts.add_link(DependencyLink {
+    ///     prec: "compile",
+    ///     succ: "link"
+    /// }));
+    ///
+    /// assert_eq!(ts.pop(), Some("compile"));
+    /// assert_eq!(ts.pop(), Some("link"));
+    /// ```
     pub fn add_link(&mut self, link: DependencyLink<T>) -> bool {
         self.add_dependency(link.prec, link.succ)
     }
 
     /// Inserts an item, without adding any dependencies from or to it.
     ///
-    /// If the `TopologicalSort` did not have this item present, `true` is returned.
+    /// Returns `true` if the item was not already present, or `false` otherwise.
     ///
-    /// If the `TopologicalSort` already had this item present, `false` is returned.
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// assert!(ts.insert("standalone"));
+    /// assert!(!ts.insert("standalone"));
+    ///
+    /// assert_eq!(ts.pop(), Some("standalone"));
+    /// ```
     pub fn insert<U>(&mut self, item: U) -> bool
     where
         U: Into<T>,
@@ -163,9 +320,20 @@ where
     /// `None` if there is no such item.
     ///
     /// If `pop` returns `None` and `len` is not 0, the remaining items contain a cycle.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// ts.add_dependency("a", "b");
+    ///
+    /// assert_eq!(ts.pop(), Some("a"));
+    /// assert_eq!(ts.pop(), Some("b"));
+    /// assert_eq!(ts.pop(), None);
+    /// ```
     pub fn pop(&mut self) -> Option<T> {
         self.peek().cloned().inspect(|key| {
-            self.remove(key);
+            self.remove_node(key);
         })
     }
 
@@ -203,6 +371,20 @@ where
     ///
     /// If `pop_batch` returns an empty vector and `len` is not 0, the remaining items contain a
     /// cycle.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::<i32>::new();
+    /// ts.add_dependency(1, 3);
+    /// ts.add_dependency(2, 3);
+    ///
+    /// let mut ready = ts.pop_batch();
+    /// ready.sort_unstable();
+    /// assert_eq!(ready, vec![1, 2]);
+    ///
+    /// assert_eq!(ts.pop_batch(), vec![3]);
+    /// ```
     pub fn pop_batch(&mut self) -> Vec<T> {
         let keys = self
             .nodes
@@ -211,13 +393,24 @@ where
             .map(|(k, _)| k.clone())
             .collect::<Vec<_>>();
         for k in &keys {
-            self.remove(k);
+            self.remove_node(k);
         }
         keys
     }
 
     /// Returns a reference to one item that does not depend on any other remaining item, or
     /// `None` if there is no such item.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// ts.add_dependency("a", "b");
+    ///
+    /// assert_eq!(ts.peek(), Some(&"a"));
+    /// assert_eq!(ts.len(), 2);
+    /// assert_eq!(ts.pop(), Some("a"));
+    /// ```
     #[must_use]
     pub fn peek(&self) -> Option<&T> {
         self.nodes
@@ -231,6 +424,19 @@ where
     /// of the call, or an empty vector if there are no such items.
     ///
     /// This inspects only the current batch of ready items.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::<i32>::new();
+    /// ts.add_dependency(1, 3);
+    /// ts.add_dependency(2, 3);
+    ///
+    /// let mut ready = ts.peek_batch();
+    /// ready.sort_unstable();
+    /// assert_eq!(ready, vec![&1, &2]);
+    /// assert_eq!(ts.len(), 3);
+    /// ```
     #[must_use]
     pub fn peek_batch(&self) -> Vec<&T> {
         self.nodes
@@ -240,16 +446,56 @@ where
             .collect::<Vec<_>>()
     }
 
-    fn remove(&mut self, prec: &T) -> Option<Node<T>> {
-        let result = self.nodes.remove(prec);
-        if let Some(ref p) = result {
-            for s in &p.succ {
-                if let Some(y) = self.nodes.get_mut(s) {
-                    y.num_prec -= 1;
-                }
+    /// Removes the specified item if it does not depend on any other remaining item and returns
+    /// it.
+    ///
+    /// Returns `None` if the item is not present or if it still depends on another remaining item.
+    ///
+    /// Removing the item also removes its outgoing dependency links, which may make some successor
+    /// items ready.
+    ///
+    /// ```rust
+    /// use topological_sort::TopologicalSort;
+    ///
+    /// let mut ts = TopologicalSort::new();
+    /// ts.add_dependency("a", "b");
+    ///
+    /// assert_eq!(ts.remove("b"), None);
+    /// assert_eq!(ts.remove("a"), Some("a"));
+    /// assert_eq!(ts.remove("b"), Some("b"));
+    /// ```
+    pub fn remove<Q>(&mut self, item: &Q) -> Option<T>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let item_node = self.nodes.get(item)?;
+        if item_node.num_prec != 0 {
+            return None;
+        }
+        let (item, _) = self.remove_node(item)?;
+        Some(item)
+    }
+
+    fn remove_node<Q>(&mut self, item: &Q) -> Option<(T, Node<T>)>
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+    {
+        let (item, item_node) = self.nodes.remove_entry(item)?;
+        // `remove_node` updates only the removed node's successors. Callers must ensure the node
+        // has no remaining predecessors, or predecessor nodes would retain stale links to it and
+        // break the internal invariants.
+        debug_assert_eq!(
+            item_node.num_prec, 0,
+            "remove_node assumes the removed item has no predecessors"
+        );
+        for succ in &item_node.succ {
+            if let Some(succ_node) = self.nodes.get_mut(succ.borrow()) {
+                succ_node.num_prec -= 1;
             }
         }
-        result
+        Some((item, item_node))
     }
 }
 
@@ -365,7 +611,7 @@ mod tests {
     }
 
     #[test]
-    fn pop_iter_iterates_all_elements_in_topological_order() {
+    fn pop_iter_iterates_all_items_in_topological_order() {
         let mut ts = TopologicalSort::<i32>::new();
         ts.add_dependency(1, 2);
         ts.add_dependency(2, 3);
@@ -402,7 +648,7 @@ mod tests {
     }
 
     #[test]
-    fn pop_batch_returns_all_currently_available_elements() {
+    fn pop_batch_returns_all_currently_ready_items() {
         fn check(result: &[i32], ts: &mut TopologicalSort<i32>) {
             let l = ts.len();
             let mut v = ts.pop_batch();
@@ -483,6 +729,21 @@ mod tests {
         assert_eq!(ts.len(), 3);
         assert_eq!(ts.pop(), Some("omelet"));
         assert_eq!(ts.pop(), None);
+    }
+
+    #[test]
+    fn remove_removes_item_only_if_exists_and_ready() {
+        let mut ts = TopologicalSort::<&str>::new();
+        ts.add_dependency("a", "b");
+        ts.add_dependency("b", "c");
+        ts.add_dependency("c", "d");
+
+        assert!(ts.remove("x").is_none());
+        assert!(ts.remove("c").is_none());
+        assert_eq!(ts.remove("a").unwrap(), "a");
+        assert!(ts.remove("c").is_none());
+        assert_eq!(ts.remove("b").unwrap(), "b");
+        assert_eq!(ts.remove("c").unwrap(), "c");
     }
 
     #[quickcheck]


### PR DESCRIPTION
## Summary
- add `TopologicalSort::remove()` to remove a specific ready item
- refactor the internal removal helper used by `pop()` and `pop_batch()` and document its invariants
- expand the crate-level and method-level Rustdoc examples, including examples for Makefile-style dependencies, cycle detection, sequential processing, and a task-queue-style scheduler
- sync the README and changelog with the new API and documentation

## Motivation
`TopologicalSort` could previously remove only an arbitrary ready item via `pop()` or the current ready batch via `pop_batch()`. This change adds a way to remove a specific ready item while preserving the existing invariants, and documents the intended usage patterns more clearly.

## Validation
- `cargo test`
