### PR TITLE
Use extract_if in ready-node removal paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * **(Breaking Change)** `TopologicalSort::add_dependency()` and `TopologicalSort::add_link()` now return `true` when they add a new dependency link and `false` when that link already existed.
-* Raised the minimum supported Rust version to Rust 1.85.0.
+* Raised the minimum supported Rust version to Rust 1.88.0.
 * Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
 * Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_batch()`, which may produce new warnings when their return values are ignored.
 * **(Breaking Change)** Renamed `TopologicalSort::pop_all()` to `TopologicalSort::pop_batch()` and `TopologicalSort::peek_all()` to `TopologicalSort::peek_batch()`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "topological-sort"
 version = "0.2.2"
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.88.0"
 description = "Performs topological sorting."
 documentation = "https://docs.rs/topological-sort"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/topological-sort.svg?)](#license)
 [![crates.io](https://img.shields.io/crates/v/topological-sort.svg?logo=rust)](https://crates.io/crates/topological-sort)
 [![docs.rs](https://img.shields.io/docsrs/topological-sort.svg?logo=docs.rs)](https://docs.rs/topological-sort)
-[![Rust: ^1.85.0](https://img.shields.io/badge/rust-^1.85.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
+[![Rust: ^1.88.0](https://img.shields.io/badge/rust-^1.88.0-93450a.svg?logo=rust)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![GitHub Actions: CI](https://img.shields.io/github/actions/workflow/status/gifnksm/topological-sort-rs/ci.yml.svg?label=CI&logo=github)](https://github.com/gifnksm/topological-sort-rs/actions/workflows/ci.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/gifnksm/topological-sort-rs.svg?label=codecov&logo=codecov)](https://codecov.io/gh/gifnksm/topological-sort-rs)
 <!-- cargo-sync-rdme ]] -->
@@ -163,7 +163,7 @@ topological-sort = "0.2.2"
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.85.0**.
+The minimum supported Rust version is **Rust 1.88.0**.
 
 While a crate is pre-release status (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@ where
             succ: HashSet::new(),
         }
     }
+
+    fn is_ready(&self) -> bool {
+        self.num_prec == 0
+    }
 }
 
 /// A data structure for topological sorting.
@@ -238,30 +242,13 @@ where
     {
         let prec = prec.into();
         let succ = succ.into();
-        match self.nodes.entry(prec) {
-            Entry::Vacant(e) => {
-                let mut dep = Node::new();
-                dep.succ.insert(succ.clone());
-                e.insert(dep);
-            }
-            Entry::Occupied(e) => {
-                if !e.into_mut().succ.insert(succ.clone()) {
-                    // Already registered
-                    return false;
-                }
-            }
-        }
 
-        match self.nodes.entry(succ) {
-            Entry::Vacant(e) => {
-                let mut dep = Node::new();
-                dep.num_prec += 1;
-                e.insert(dep);
-            }
-            Entry::Occupied(e) => {
-                e.into_mut().num_prec += 1;
-            }
+        let prec_node = self.nodes.entry(prec).or_insert_with(Node::new);
+        if !prec_node.succ.insert(succ.clone()) {
+            // Already registered
+            return false;
         }
+        self.nodes.entry(succ).or_insert_with(Node::new).num_prec += 1;
         true
     }
 
@@ -308,8 +295,7 @@ where
     {
         match self.nodes.entry(item.into()) {
             Entry::Vacant(e) => {
-                let dep = Node::new();
-                e.insert(dep);
+                e.insert(Node::new());
                 true
             }
             Entry::Occupied(_) => false,
@@ -332,9 +318,13 @@ where
     /// assert_eq!(ts.pop(), None);
     /// ```
     pub fn pop(&mut self) -> Option<T> {
-        self.peek().cloned().inspect(|key| {
-            self.remove_node(key);
-        })
+        let (item, node) = self.nodes.extract_if(|_, node| node.is_ready()).next()?;
+        for succ in node.succ {
+            if let Some(succ_node) = self.nodes.get_mut(&succ) {
+                succ_node.num_prec -= 1;
+            }
+        }
+        Some(item)
     }
 
     /// Returns an iterator that repeatedly calls [`pop`](Self::pop).
@@ -386,16 +376,18 @@ where
     /// assert_eq!(ts.pop_batch(), vec![3]);
     /// ```
     pub fn pop_batch(&mut self) -> Vec<T> {
-        let keys = self
+        let (items, nodes) = self
             .nodes
-            .iter()
-            .filter(|&(_, v)| v.num_prec == 0)
-            .map(|(k, _)| k.clone())
-            .collect::<Vec<_>>();
-        for k in &keys {
-            self.remove_node(k);
+            .extract_if(|_, node| node.is_ready())
+            .collect::<(Vec<_>, Vec<_>)>();
+        for node in nodes {
+            for succ in node.succ {
+                if let Some(succ_node) = self.nodes.get_mut(&succ) {
+                    succ_node.num_prec -= 1;
+                }
+            }
         }
-        keys
+        items
     }
 
     /// Returns a reference to one item that does not depend on any other remaining item, or
@@ -415,8 +407,8 @@ where
     pub fn peek(&self) -> Option<&T> {
         self.nodes
             .iter()
-            .filter(|&(_, v)| v.num_prec == 0)
-            .map(|(k, _)| k)
+            .filter(|&(_, node)| node.is_ready())
+            .map(|(item, _)| item)
             .next()
     }
 
@@ -441,8 +433,8 @@ where
     pub fn peek_batch(&self) -> Vec<&T> {
         self.nodes
             .iter()
-            .filter(|&(_, v)| v.num_prec == 0)
-            .map(|(k, _)| k)
+            .filter(|&(_, node)| node.is_ready())
+            .map(|(item, _)| item)
             .collect::<Vec<_>>()
     }
 
@@ -469,33 +461,17 @@ where
         T: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        let item_node = self.nodes.get(item)?;
-        if item_node.num_prec != 0 {
+        let node = self.nodes.get(item)?;
+        if !node.is_ready() {
             return None;
         }
-        let (item, _) = self.remove_node(item)?;
-        Some(item)
-    }
-
-    fn remove_node<Q>(&mut self, item: &Q) -> Option<(T, Node<T>)>
-    where
-        T: Borrow<Q>,
-        Q: Eq + Hash + ?Sized,
-    {
-        let (item, item_node) = self.nodes.remove_entry(item)?;
-        // `remove_node` updates only the removed node's successors. Callers must ensure the node
-        // has no remaining predecessors, or predecessor nodes would retain stale links to it and
-        // break the internal invariants.
-        debug_assert_eq!(
-            item_node.num_prec, 0,
-            "remove_node assumes the removed item has no predecessors"
-        );
-        for succ in &item_node.succ {
+        let (item, node) = self.nodes.remove_entry(item)?;
+        for succ in node.succ {
             if let Some(succ_node) = self.nodes.get_mut(succ.borrow()) {
                 succ_node.num_prec -= 1;
             }
         }
-        Some((item, item_node))
+        Some(item)
     }
 }
 


### PR DESCRIPTION
## Summary
- use `HashMap::extract_if` to remove ready nodes directly in `pop` and `pop_batch`
- inline the old removal helper logic and reuse `Node::is_ready()` in the ready checks
- raise the MSRV to Rust 1.88.0 and update the changelog and README to match

## Motivation
The ready-node removal paths can be implemented more directly with `extract_if`, which simplifies the control flow and removes the dedicated helper used only for node removal.

## Validation
- `cargo test`
- `cargo +1.88.0 test`

## Impact
- implementation is simpler and more direct in the ready-item removal paths
- MSRV increases from Rust 1.85.0 to Rust 1.88.0 because `HashMap::extract_if` is now required

## Risks / follow-up
- no functional change is intended beyond the documented MSRV bump