### PR TITLE
Restore deprecated batch methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added `TopologicalSort::items()` and `TopologicalSort::into_items()` to iterate over all remaining items, including ones that are still blocked by unresolved dependencies or cycles.
 * Implemented `Extend<DependencyLink<T>>` for `TopologicalSort<T>`, allowing dependency links to be appended with `extend()`.
 * Added `TopologicalSort::pop_iter()`, which returns a `PopIter<'_, T>` that repeatedly calls `pop()`.
+* Added `TopologicalSort::pop_batch()`, which removes and returns the current batch of ready items and can collect into any collection implementing `Default + Extend<T>`.
+* Added `TopologicalSort::peek_batch()`, which iterates over the current batch of ready items.
 * Added `TopologicalSort::remove()`, which removes a specified item only when it has no remaining dependencies.
 * Added `CHANGELOG.md`.
 
@@ -23,24 +25,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Raised the minimum supported Rust version to Rust 1.88.0.
 * Adjusted `TopologicalSort<T>` debug output to use a more collection-like representation of dependency relationships.
 * Added `#[must_use]` to `TopologicalSort::new()`, `len()`, `is_empty()`, `peek()`, and `peek_batch()`, which may produce new warnings when their return values are ignored.
-* **(Breaking Change)** Renamed `TopologicalSort::pop_all()` to `TopologicalSort::pop_batch()`. `pop_batch()` now returns any collection implementing `Default + Extend<T>`.
+
+### Deprecated
+
+* Deprecated `TopologicalSort::pop_all()` in favor of `TopologicalSort::pop_batch()`.
   * **Rationale:**
     The old name could be taken to mean that the method would keep popping items until no more progress was possible.
     However, it only removed the current batch of items that had no remaining dependencies at the time of the call.
     The new name makes that batch-oriented behavior explicit and helps avoid using a single `pop_all()` call as a cycle check.
 
-    The new return type also avoids unnecessary intermediate collection work.
+    `pop_batch()` also avoids unnecessary intermediate collection work.
     Callers can now collect directly into their chosen container instead of always receiving a `Vec`.
   * **Migration notes:**
     * Replace `ts.pop_all()` with `ts.pop_batch::<Vec<_>>()` when you still want a `Vec`.
     * If you intended to keep popping until no more progress is possible, use `ts.pop_iter()` instead, for example `let items: Vec<_> = ts.pop_iter().collect();`.
-* **(Breaking Change)** Renamed `TopologicalSort::peek_all()` to `TopologicalSort::peek_batch()`. `peek_batch()` now returns an iterator instead of allocating a `Vec<&T>`.
+* Deprecated `TopologicalSort::peek_all()` in favor of `TopologicalSort::peek_batch()`.
   * **Rationale:**
     The old name could be taken to mean that the method would inspect every item that would become ready as popping progressed.
     However, it only inspected the current batch of items that had no remaining dependencies at the time of the call.
     The new name makes that batch-oriented behavior explicit.
 
-    Returning an iterator also avoids unnecessary allocation when callers only need to inspect or stream the ready items.
+    `peek_batch()` also avoids unnecessary allocation when callers only need to inspect or stream the ready items.
   * **Migration notes:**
     * Replace `ts.peek_all()` with `ts.peek_batch().collect::<Vec<_>>()` when you still want `Vec<&T>`.
     * If you want owned copied values from `peek_batch()`, use `ts.peek_batch().copied().collect::<Vec<_>>()` for `Copy` types or `ts.peek_batch().cloned().collect::<Vec<_>>()` for `Clone` types.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,6 +363,20 @@ where
     }
 
     /// Removes all items that do not depend on any other remaining item at the time of the call
+    /// and returns them, or an empty vector if there are no such items.
+    ///
+    /// The returned items are in arbitrary order.
+    ///
+    /// If `pop_all` returns an empty vector and the sort is not empty, the remaining items contain a cycle.
+    #[deprecated(
+        since = "0.3.0",
+        note = "Use `pop_batch` instead, which returns an arbitrary collection containing all ready items."
+    )]
+    pub fn pop_all(&mut self) -> Vec<T> {
+        self.pop_batch()
+    }
+
+    /// Removes all items that do not depend on any other remaining item at the time of the call
     /// and returns them, or an empty collection if there are no such items.
     ///
     /// Unlike [`pop_iter`](Self::pop_iter), this removes only the current batch of ready items. If
@@ -371,7 +385,7 @@ where
     ///
     /// The returned items are in arbitrary order.
     ///
-    /// If `pop_batch` returns an empty collection and `len` is not 0, the remaining items contain
+    /// If `pop_batch` returns an empty collection and the sort is not empty, the remaining items contain
     /// a cycle.
     ///
     /// ```rust
@@ -422,6 +436,19 @@ where
     pub fn peek(&self) -> Option<&T> {
         let (item, _) = self.nodes.iter().find(|&(_, node)| node.is_ready())?;
         Some(item)
+    }
+
+    /// Returns a vector of references to all items that do not depend on any other remaining item at
+    /// the time of the call.
+    ///
+    /// The returned items are in arbitrary order.
+    #[deprecated(
+        since = "0.3.0",
+        note = "Use `peek_batch` instead, which returns an iterator over all ready items."
+    )]
+    #[must_use]
+    pub fn peek_all(&self) -> Vec<&T> {
+        self.peek_batch().collect()
     }
 
     /// Returns an iterator over references to all items that do not depend on any other remaining


### PR DESCRIPTION
## Summary

- restore `TopologicalSort::pop_all()` as a deprecated compatibility wrapper around `pop_batch()`
- restore `TopologicalSort::peek_all()` as a deprecated compatibility wrapper around `peek_batch()`
- update `CHANGELOG.md` to describe these as deprecated APIs instead of breaking removals
- keep the doc wording consistent around cycle detection for `pop_batch()`

## Motivation

Removing `peek_all()` and `pop_all()` entirely felt too aggressive for this release. Keeping them as deprecated methods preserves a smoother migration path while still steering callers toward the newer batch-oriented APIs.

## Validation

- `cargo test`
- markdown diagnostics for `CHANGELOG.md`

## Impact

This reduces migration friction for existing users by preserving the old methods with deprecation warnings rather than forcing an immediate rename.